### PR TITLE
chore: Fixed start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "packageManager": "yarn@3.1.1",
   "scripts": {
-    "start": "concurrently -n demo,css,react -k \"yarn start:demo\" \"yarn build:css:watch\" \"yarn build:react:watch\"",
+    "start": "yarn build:css && yarn build:react && concurrently -n demo,css,react -k \"yarn start:demo\" \"yarn build:css:watch\" \"yarn build:react:watch\"",
     "start:demo": "yarn workspace @itwin/itwinui-layouts-demo dev",
     "build:demo": "yarn workspace @itwin/itwinui-layouts-demo build",
     "build:css": "yarn workspace @itwin/itwinui-layouts-css build",


### PR DESCRIPTION
`yarn start` was failing when trying to run at very beginning since there are no built CSS and React packages. Now it will build everything before starting the demo app.