### PR TITLE
Content area padding changes based off side navigation being present

### DIFF
--- a/packages/layouts-css/src/page.scss
+++ b/packages/layouts-css/src/page.scss
@@ -17,6 +17,7 @@
   &-sidenav {
     grid-area: sidenav;
 
+    //#region If side navigation is present, remove the env(safe-area-inset-left) from the left side of content area
     ~ .iui-layouts-page-content-padded {
       @include monitor {
         padding-left: $iui-xxl;
@@ -38,6 +39,7 @@
         padding-left: $iui-l;
       }
     }
+    //#endregion If side navigation is present, remove the env(safe-area-inset-left) from the left side of content area
   }
 
   &-content {
@@ -50,6 +52,7 @@
       flex-direction: column;
       align-items: center;
 
+      //#region Add env(safe-area-inset-*) for iPhone notch on the left & right sides of content area
       @include monitor {
         padding: $iui-xl unquote('max(#{$iui-xxl}, env(safe-area-inset-right))') $iui-xl unquote('max(#{$iui-xxl}, env(safe-area-inset-left))');
       }
@@ -69,6 +72,7 @@
       @include mobile {
         padding: $iui-s unquote('max(#{$iui-l}, env(safe-area-inset-right))') $iui-s unquote('max(#{$iui-l}, env(safe-area-inset-left))');
       }
+      //#endregion Add env(safe-area-inset-*) for iPhone notch on the left & right sides of content area
     }
 
     &-centered {

--- a/packages/layouts-css/src/page.scss
+++ b/packages/layouts-css/src/page.scss
@@ -51,23 +51,23 @@
       align-items: center;
 
       @include monitor {
-        padding: $iui-xl unquote('max(#{$iui-xxl}, #{$iui-xxl} + env(safe-area-inset-right))') $iui-xl unquote('max(#{$iui-xxl}, #{$iui-xxl} + env(safe-area-inset-left))');
+        padding: $iui-xl unquote('max(#{$iui-xxl}, env(safe-area-inset-right))') $iui-xl unquote('max(#{$iui-xxl}, env(safe-area-inset-left))');
       }
 
       @include small-monitor {
-        padding: $iui-l unquote('max(48px, 48px + env(safe-area-inset-right))') $iui-l unquote('max(48px, 48px + env(safe-area-inset-left))');
+        padding: $iui-l unquote('max(48px, env(safe-area-inset-right))') $iui-l unquote('max(48px, env(safe-area-inset-left))');
       }
 
       @include tablet {
-        padding: $iui-m unquote('max(#{$iui-xl}, #{$iui-xl} + env(safe-area-inset-right))') $iui-m unquote('max(#{$iui-xl}, #{$iui-xl} + env(safe-area-inset-left))');
+        padding: $iui-m unquote('max(#{$iui-xl}, env(safe-area-inset-right))') $iui-m unquote('max(#{$iui-xl}, env(safe-area-inset-left))');
       }
 
       @include landscape-mobile {
-        padding: $iui-s unquote('max(#{$iui-l}, #{$iui-l} + env(safe-area-inset-right))') $iui-s unquote('max(#{$iui-l}, #{$iui-l} + env(safe-area-inset-left))');
+        padding: $iui-s unquote('max(#{$iui-l}, env(safe-area-inset-right))') $iui-s unquote('max(#{$iui-l}, env(safe-area-inset-left))');
       }
 
       @include mobile {
-        padding: $iui-s unquote('max(#{$iui-l}, #{$iui-l} + env(safe-area-inset-right))') $iui-s unquote('max(#{$iui-l}, #{$iui-l} + env(safe-area-inset-left))');
+        padding: $iui-s unquote('max(#{$iui-l}, env(safe-area-inset-right))') $iui-s unquote('max(#{$iui-l}, env(safe-area-inset-left))');
       }
     }
 

--- a/packages/layouts-css/src/page.scss
+++ b/packages/layouts-css/src/page.scss
@@ -16,6 +16,28 @@
 
   &-sidenav {
     grid-area: sidenav;
+
+    ~ .iui-layouts-page-content-padded {
+      @include monitor {
+        padding-left: $iui-xxl;
+      }
+
+      @include small-monitor {
+        padding-left: 48px;
+      }
+
+      @include tablet {
+        padding-left: $iui-xl;
+      }
+
+      @include landscape-mobile {
+        padding-left: $iui-l;
+      }
+
+      @include mobile {
+        padding-left: $iui-l;
+      }
+    }
   }
 
   &-content {
@@ -29,23 +51,23 @@
       align-items: center;
 
       @include monitor {
-        padding: $iui-xl unquote('max(#{$iui-xxl}, #{$iui-xxl} + env(safe-area-inset-right))') $iui-xl $iui-xxl;
+        padding: $iui-xl unquote('max(#{$iui-xxl}, #{$iui-xxl} + env(safe-area-inset-right))') $iui-xl unquote('max(#{$iui-xxl}, #{$iui-xxl} + env(safe-area-inset-left))');
       }
 
       @include small-monitor {
-        padding: $iui-l unquote('max(48px, 48px + env(safe-area-inset-right))') $iui-l 48px;
+        padding: $iui-l unquote('max(48px, 48px + env(safe-area-inset-right))') $iui-l unquote('max(48px, 48px + env(safe-area-inset-left))');
       }
 
       @include tablet {
-        padding: $iui-m unquote('max(#{$iui-xl}, #{$iui-xl} + env(safe-area-inset-right))') $iui-m $iui-xl;
+        padding: $iui-m unquote('max(#{$iui-xl}, #{$iui-xl} + env(safe-area-inset-right))') $iui-m unquote('max(#{$iui-xl}, #{$iui-xl} + env(safe-area-inset-left))');
       }
 
       @include landscape-mobile {
-        padding: $iui-s unquote('max(#{$iui-l}, #{$iui-l} + env(safe-area-inset-right))') $iui-s $iui-l;
+        padding: $iui-s unquote('max(#{$iui-l}, #{$iui-l} + env(safe-area-inset-right))') $iui-s unquote('max(#{$iui-l}, #{$iui-l} + env(safe-area-inset-left))');
       }
 
       @include mobile {
-        padding: $iui-s unquote('max(#{$iui-l}, #{$iui-l} + env(safe-area-inset-right))') $iui-s $iui-l;
+        padding: $iui-s unquote('max(#{$iui-l}, #{$iui-l} + env(safe-area-inset-right))') $iui-s unquote('max(#{$iui-l}, #{$iui-l} + env(safe-area-inset-left))');
       }
     }
 


### PR DESCRIPTION
- When the side navigation is removed & in horizontal view both sides have equal padding now.
- When the side navigation is present & in horizontal view the left side padding is reduced because it is not needed.  Does require `.iui-layouts-page-sidenav` to be placed before `.iui-layouts-page-content` to work as intended.
- Replaced `unquote('max(#{$iui-xxl}, #{$iui-xxl} + env(safe-area-inset-right))')` with `unquote('max(#{$iui-xxl}, env(safe-area-inset-right))')` to show more content on the screen.

**Before:**
![MicrosoftTeams-image (5)](https://user-images.githubusercontent.com/849817/168846241-a05759af-16b7-48df-8a60-5548a1c20fa7.png)

**After:**
![Screen Shot 2022-05-17 at 11 21 06 AM](https://user-images.githubusercontent.com/849817/168847764-501e10ce-22f2-4d6d-bef0-418770e79f96.png)

