### PR TITLE
chore: Release action fixes

### DIFF
--- a/.github/workflows/release-css.yml
+++ b/.github/workflows/release-css.yml
@@ -19,7 +19,9 @@ jobs:
       - run: yarn install
       - run: yarn build
 
-      - run: yarn npm publish --access public --tag dev
+      - run: yarn pack --out release.tgz
+        working-directory: './packages/layouts-css'
+      - run: npm publish ./release.tgz --access public --tag dev
         working-directory: './packages/layouts-css'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}

--- a/.github/workflows/release-react.yml
+++ b/.github/workflows/release-react.yml
@@ -19,7 +19,9 @@ jobs:
       - run: yarn install
       - run: yarn build
 
-      - run: yarn npm publish --access public --tag dev
+      - run: yarn pack --out release.tgz
+        working-directory: './packages/layouts-react'
+      - run: npm publish ./release.tgz --access public --tag dev
         working-directory: './packages/layouts-react'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}

--- a/packages/layouts-css/package.json
+++ b/packages/layouts-css/package.json
@@ -10,6 +10,10 @@
   "exports": {
     "./*": "./dist/*"
   },
+  "files": [
+    "dist",
+    "LICENSE.md"
+  ],
   "scripts": {
     "build": "sass --no-source-map --load-path=../../node_modules src:dist && postcss dist --replace --no-map",
     "build:watch": "chokidar \"src/**/*\" -c \"yarn build\""

--- a/packages/layouts-react/package.json
+++ b/packages/layouts-react/package.json
@@ -15,6 +15,10 @@
       "require": "./dist/cjs/index.js"
     }
   },
+  "files": [
+    "dist",
+    "LICENSE.md"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/iTwin/iTwinUI-layouts",
   "repository": {


### PR DESCRIPTION
For some reason `yarn npm publish` didn't have the token, it might need to be passed to `.yarnrc` which we don't want to do, so I just changed to pack everything with yarn and publish with npm.
Also, I saw that all package folder content is being packed so now it only packs selected files.