### PR TITLE
chore: Writing token to ymlrc

### DIFF
--- a/.github/workflows/release-css.yml
+++ b/.github/workflows/release-css.yml
@@ -19,9 +19,10 @@ jobs:
       - run: yarn install
       - run: yarn build
 
-      - run: yarn pack --out release.tgz
-        working-directory: './packages/layouts-css'
-      - run: npm publish ./release.tgz --access public
-        working-directory: './packages/layouts-css'
+      # Writes token to .yarnrc.yml
+      - run: |
+          echo npmAuthToken: "$NODE_AUTH_TOKEN" >> ./.yarnrc.yml
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}
+      - run: yarn npm publish --access public
+        working-directory: './packages/layouts-css'

--- a/.github/workflows/release-react.yml
+++ b/.github/workflows/release-react.yml
@@ -19,9 +19,10 @@ jobs:
       - run: yarn install
       - run: yarn build
 
-      - run: yarn pack --out release.tgz
-        working-directory: './packages/layouts-react'
-      - run: npm publish ./release.tgz --access public
-        working-directory: './packages/layouts-react'
+      # Writes token to .yarnrc.yml
+      - run: |
+          echo npmAuthToken: "$NODE_AUTH_TOKEN" >> ./.yarnrc.yml
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}
+      - run: yarn npm publish --access public
+        working-directory: './packages/layouts-react'

--- a/packages/layouts-react/package.json
+++ b/packages/layouts-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/itwinui-layouts-react",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "Bentley Systems, Inc.",
     "url": "http://www.bentley.com"


### PR DESCRIPTION
Previously I was getting `No authentication configured for request` when tried to run `yarn npm publish`. This issue tells to have a token configured https://github.com/yarnpkg/berry/issues/1088 so I am adding it on the fly.