### PR TITLE
chore: release 0.1.3

### DIFF
--- a/packages/layouts-css/CHANGELOG.md
+++ b/packages/layouts-css/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.3 (2022-06-22)
+
+- **`Grid.Item`**: Added `max-width: 100%` to fix overflow in Firefox.
+
 ## 0.1.1 (2022-05-25)
 
 ### What's new

--- a/packages/layouts-css/package.json
+++ b/packages/layouts-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/itwinui-layouts-css",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "author": {
     "name": "Bentley Systems, Inc.",
     "url": "http://www.bentley.com"

--- a/packages/layouts-react/CHANGELOG.md
+++ b/packages/layouts-react/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.3 (2022-06-22)
+
+- **`Grid.Item`**: Added `max-width: 100%` to fix overflow in Firefox.
+
 ## 0.1.2 (2022-05-26)
 
 ### What's new

--- a/packages/layouts-react/package.json
+++ b/packages/layouts-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/itwinui-layouts-react",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "Bentley Systems, Inc.",
     "url": "http://www.bentley.com"


### PR DESCRIPTION
Releasing both `layouts-css` and `layouts-react`.

Skipped one version in `layouts-css` to align with `layouts-react`.