### PR TITLE
Release 0.3.0

### DIFF
--- a/packages/layouts-css/CHANGELOG.md
+++ b/packages/layouts-css/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.3.0 (2023-09-20)
+
+### Changes
+
+- [#72](https://github.com/iTwin/iTwinUI-layouts/pull/72): Breakpoints:
+  - Removed landscape-mobile breakpoint.
+  - Using rem instead of px.
+
+### What's new
+
+- [#70](https://github.com/iTwin/iTwinUI-layouts/pull/70): Page layout:
+  - Added bottom-bar area in page grid.
+  - Added action-bar layout for bottom-bar.
+
 ## 0.2.0 (2022-11-16)
 
 - Using `iTwinUI-variables`

--- a/packages/layouts-css/package.json
+++ b/packages/layouts-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/itwinui-layouts-css",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "Bentley Systems, Inc.",
     "url": "http://www.bentley.com"

--- a/packages/layouts-react/CHANGELOG.md
+++ b/packages/layouts-react/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.3.0 (2023-09-20)
+
+### Changes
+
+- [#72](https://github.com/iTwin/iTwinUI-layouts/pull/72): **GridItem**: removed `landscapeMobile` breakpoint from `ColumnSpan` and `ColumnStart` types.
+- [#72](https://github.com/iTwin/iTwinUI-layouts/pull/72): Improved breakpoints for page and grid layouts.
+
+### What's new
+
+- [#70](https://github.com/iTwin/iTwinUI-layouts/pull/70): Added a sticky `BottomBar` and `ActionBar` layout to use within BottomBar. ActionBar has 3 slots for custom components: `ActionBar.Left`, `ActionBar.Center` and `ActionBar.Right`.
+
+```
+<PageLayout.BottomBar>
+  <ActionBar>
+    <ActionBar.Left/>
+    <ActionBar.Center/>
+    <ActionBar.Right/>
+  </ActionBar>
+</PageLayout.BottomBar>
+```
+
 ## 0.2.0 (2022-11-16)
 
 - Using `iTwinUI-variables`

--- a/packages/layouts-react/package.json
+++ b/packages/layouts-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/itwinui-layouts-react",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "Bentley Systems, Inc.",
     "url": "http://www.bentley.com"


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI-layouts.
-->

## iTwinUI-layouts-css 0.3.0
### Changes

- [#72](https://github.com/iTwin/iTwinUI-layouts/pull/72): Breakpoints:
  - Removed landscape-mobile breakpoint.
  - Using rem instead of px.

### What's new

- [#70](https://github.com/iTwin/iTwinUI-layouts/pull/70): Page layout:
  - Added bottom-bar area in page grid.
  - Added action-bar layout for bottom-bar.

## iTwinUI-layouts-react 0.3.0

### Changes

- [#72](https://github.com/iTwin/iTwinUI-layouts/pull/72): **GridItem**: removed `landscapeMobile` breakpoint from `ColumnSpan` and `ColumnStart` types.
- [#72](https://github.com/iTwin/iTwinUI-layouts/pull/72): Improved breakpoints for page and grid layouts.

### What's new

- [#70](https://github.com/iTwin/iTwinUI-layouts/pull/70): Added a sticky `BottomBar` and `ActionBar` layout to use within BottomBar. ActionBar has 3 slots for custom components: `ActionBar.Left`, `ActionBar.Center` and `ActionBar.Right`.

```
<PageLayout.BottomBar>
  <ActionBar>
    <ActionBar.Left/>
    <ActionBar.Center/>
    <ActionBar.Right/>
  </ActionBar>
</PageLayout.BottomBar>
```
